### PR TITLE
Fix: Heartbeat test timeouts and improve shutdown responsiveness

### DIFF
--- a/knowledgebeast/core/heartbeat.py
+++ b/knowledgebeast/core/heartbeat.py
@@ -88,7 +88,14 @@ class KnowledgeBaseHeartbeat:
         """Background heartbeat loop with error handling."""
         while self.running:
             try:
-                time.sleep(self.interval)
+                # Sleep in small increments to allow quick shutdown
+                # This avoids long wait times when stopping the heartbeat
+                elapsed = 0
+                sleep_increment = 0.1  # 100ms increments
+                while elapsed < self.interval and self.running:
+                    time.sleep(sleep_increment)
+                    elapsed += sleep_increment
+
                 if not self.running:  # Check again after sleep
                     break
 

--- a/tests/core/test_heartbeat.py
+++ b/tests/core/test_heartbeat.py
@@ -58,7 +58,7 @@ class TestHeartbeatStartStop:
         heartbeat.stop()
         assert heartbeat.running is False
 
-    def test_start_already_running(self, kb_instance: KnowledgeBase, capsys):
+    def test_start_already_running(self, kb_instance: KnowledgeBase, caplog):
         """Test starting already running heartbeat."""
         heartbeat = KnowledgeBaseHeartbeat(kb_instance, interval=10)
         heartbeat.start()
@@ -66,8 +66,8 @@ class TestHeartbeatStartStop:
 
         # Try to start again
         heartbeat.start()
-        captured = capsys.readouterr()
-        assert "already running" in captured.out.lower()
+        # Check caplog for the warning message
+        assert any("already running" in record.message.lower() for record in caplog.records)
 
         # Cleanup
         heartbeat.stop()


### PR DESCRIPTION
## Summary

This PR fixes heartbeat test issues and significantly improves heartbeat thread shutdown responsiveness.

### Changes Made

1. **Improved Heartbeat Loop Sleep Strategy**
   - Changed from single long `time.sleep(interval)` to incremental 100ms sleeps
   - Allows heartbeat to check `self.running` flag every 100ms during sleep period
   - No functional change to heartbeat behavior - still executes at specified intervals

2. **Fixed test_start_already_running**
   - Changed from `capsys` to `caplog` fixture
   - Logger messages go to caplog, not stdout/stderr captured by capsys
   - Test now properly validates "already running" warning message

### Benefits

- **Faster Shutdown**: Heartbeat threads now shut down within 100ms instead of waiting for full interval (could be up to 5 minutes in production)
- **Better Thread Safety**: More responsive to stop() calls
- **All Tests Pass**: 22/22 tests passing
- **No Breaking Changes**: Heartbeat functionality unchanged, only internal sleep mechanism improved

### Test Execution Time

- **Before**: Tests would hang indefinitely or timeout
- **After**: 22 tests pass in ~83 seconds
- **Coverage**: Heartbeat module coverage improved to 89%

### What Was Causing Issues

1. **Long Sleep Blocking Shutdown**: `time.sleep(self.interval)` would block for the entire interval (10-300 seconds), preventing graceful shutdown
2. **Test Fixture Mismatch**: `capsys` doesn't capture logger output, needed `caplog` instead

### Testing

All heartbeat tests pass:
- Initialization tests
- Start/stop functionality  
- Heartbeat execution
- Cache refresh
- Health metrics
- Graceful shutdown
- Context manager
- Error handling
- Thread safety

```bash
pytest tests/core/test_heartbeat.py -v
# 22 passed in 83.54s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)